### PR TITLE
Implemented gatsby-plugin-preload-fonts

### DIFF
--- a/font-preload-cache.json
+++ b/font-preload-cache.json
@@ -1,0 +1,1 @@
+{"timestamp":1597968716116,"hash":"f08818d6558535ceade77e9ecfd4206f","assets":{}}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,6 +47,7 @@ module.exports = {
     "gatsby-transformer-sharp",
     "gatsby-plugin-sharp",
     "gatsby-plugin-offline",
+    "gatsby-plugin-preload-fonts",
     {
       resolve: "gatsby-plugin-sass",
       options: {

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,3 +5,7 @@
  */
 
 // You can delete this file if you're not using it
+import "typeface-droid-serif";
+import "typeface-kaushan-script";
+import "typeface-montserrat";
+import "typeface-roboto-slab";

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
-    "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
+    "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "bootstrap": "^4.4.1",
     "clsx": "^1.1.0",
@@ -19,6 +19,7 @@
     "gatsby-plugin-i18n": "^1.0.1",
     "gatsby-plugin-manifest": "^2.3.3",
     "gatsby-plugin-offline": "^3.1.2",
+    "gatsby-plugin-preload-fonts": "^1.2.20",
     "gatsby-plugin-react-helmet": "^3.2.2",
     "gatsby-plugin-sass": "^2.2.1",
     "gatsby-plugin-sharp": "^2.5.4",
@@ -87,6 +88,7 @@
     "serve": "gatsby serve",
     "eslint": "eslint ./src",
     "test": "cross-env NODE_ENV=test yarn run eslint",
-    "testbuild": "yarn test && yarn build"
+    "testbuild": "yarn test && yarn build",
+    "preload-fonts": "gatsby-preload-fonts"
   }
 }


### PR DESCRIPTION
Setup and installed gatsby-preload-fonts.

Ran "npm run gatsby-preload-fonts" and added the generated font-preload-cache.json to source folder.

Check out https://www.gatsbyjs.com/plugins/gatsby-plugin-preload-fonts/

Also added typeface imports to gatsby-ssr.js

For reference, please see https://github.com/gatsbyjs/gatsby/pull/14608